### PR TITLE
feat: Add EPB ownership status tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
   <!-- Modals -->
   <div class="modal-backdrop" id="modalBreakdown"><div class="modal-card"><h3 id="breakdownTitle">Member Breakdown</h3><div id="breakdownContent" style="margin-top:.5rem;"></div><div style="margin-top:.8rem;text-align:right;"><button class="btn btn-warning" onclick="window.closeModal('modalBreakdown')">Close</button></div></div></div>
   <div class="modal-backdrop" id="modalImportCsv"><div class="modal-card"><h3>Import Members from CSV</h3><div id="csvPreview" style="margin-top:.5rem;max-height:50vh;overflow:auto;border:1px solid #dee2e6;border-radius:8px;padding:.5rem;background:#f8f9fa"></div><div style="display:flex;gap:.5rem;justify-content:flex-end;margin-top:.8rem;"><button class="btn btn-warning" onclick="window.closeModal('modalImportCsv')">Cancel</button><button class="btn btn-success" id="btnConfirmImport" onclick="window.confirmCsvImport()" disabled>Import</button></div></div></div>
-  <div class="modal-backdrop" id="modalAddMember"><div class="modal-card" style="max-width:520px;"><h3 id="addEditTitle">Add New Member</h3><form id="addMemberForm" style="margin-top:.7rem;" onsubmit="window.submitMember(event)"><div class="form-group"><label for="memberName">Full Name</label><input type="text" class="form-control" id="memberName" required /></div><div class="form-group"><label for="memberRank">Rank</label><select class="form-control" id="memberRank" required><option value="">Select Rank</option><option value="AB">AB</option><option value="Amn">Amn</option><option value="A1C">A1C</option><option value="SrA">SrA</option><option value="SSgt">SSgt</option><option value="TSgt">TSgt</option><option value="MSgt">MSgt</option><option value="SMSgt">SMSgt</option><option value="CMSgt">CMSgt</option></select></div><div class="form-group"><label for="memberDOS">Date of Separation (DOS)</label><input type="date" class="form-control" id="memberDOS" required /></div><div class="form-group"><label for="memberDEROS">DEROS (YYYY-MM-DD or DD-Mon-YY)</label><input type="text" class="form-control" id="memberDEROS" placeholder="e.g., 2026-05-26 or 26-May-26" /></div><div class="form-group"><label for="memberAFSC">AFSC</label><input type="text" class="form-control" id="memberAFSC" placeholder="e.g., 3D1X2" /></div><div class="form-group"><label for="memberStatus">Status</label><select class="form-control" id="memberStatus" required><option value="">Select Status</option><option value="pending">Pending</option><option value="in_progress">In Progress</option><option value="awaiting_cc">Awaiting Commander Approval</option><option value="scheduled">Scheduled</option><option value="eligible">Eligible</option><option value="extension">Needs Extension</option><option value="separating">Separating</option><option value="completed">Completed Reenlistment</option></select></div><div style="display:flex;gap:.5rem;justify-content:flex-end;margin-top:.7rem;"><button type="button" class="btn btn-warning" onclick="window.closeModal('modalAddMember')">Cancel</button><button type="submit" class="btn btn-success">Save</button></div></form></div></div>
+  <div class="modal-backdrop" id="modalAddMember"><div class="modal-card" style="max-width:520px;"><h3 id="addEditTitle">Add New Member</h3><form id="addMemberForm" style="margin-top:.7rem;" onsubmit="window.submitMember(event)"><div class="form-group"><label for="memberName">Full Name</label><input type="text" class="form-control" id="memberName" required /></div><div class="form-group"><label for="memberRank">Rank</label><select class="form-control" id="memberRank" required><option value="">Select Rank</option><option value="AB">AB</option><option value="Amn">Amn</option><option value="A1C">A1C</option><option value="SrA">SrA</option><option value="SSgt">SSgt</option><option value="TSgt">TSgt</option><option value="MSgt">MSgt</option><option value="SMSgt">SMSgt</option><option value="CMSgt">CMSgt</option></select></div><div class="form-group"><label for="memberDOS">Date of Separation (DOS)</label><input type="date" class="form-control" id="memberDOS" required /></div><div class="form-group"><label for="memberInprocessingDate">In-processing Date</label><input type="date" class="form-control" id="memberInprocessingDate" /></div><div class="form-group"><label for="memberDEROS">DEROS (YYYY-MM-DD or DD-Mon-YY)</label><input type="text" class="form-control" id="memberDEROS" placeholder="e.g., 2026-05-26 or 26-May-26" /></div><div class="form-group"><label for="memberAFSC">AFSC</label><input type="text" class="form-control" id="memberAFSC" placeholder="e.g., 3D1X2" /></div><div class="form-group"><label for="memberStatus">Status</label><select class="form-control" id="memberStatus" required><option value="">Select Status</option><option value="pending">Pending</option><option value="in_progress">In Progress</option><option value="awaiting_cc">Awaiting Commander Approval</option><option value="scheduled">Scheduled</option><option value="eligible">Eligible</option><option value="extension">Needs Extension</option><option value="separating">Separating</option><option value="completed">Completed Reenlistment</option></select></div><div style="display:flex;gap:.5rem;justify-content:flex-end;margin-top:.7rem;"><button type="button" class="btn btn-warning" onclick="window.closeModal('modalAddMember')">Cancel</button><button type="submit" class="btn btn-success">Save</button></div></form></div></div>
   <div class="modal-backdrop" id="modalFormInfo"><div class="modal-card"><h3 id="formTitle"></h3><div id="formContent" style="margin-top:.5rem;"></div><div style="margin-top:.8rem;text-align:right;"><button class="btn btn-warning" onclick="window.closeModal('modalFormInfo')">Close</button></div></div></div>
 
   <script>
@@ -275,7 +275,7 @@
         try {
           const raw = localStorage.getItem(STORAGE_KEY);
           let loadedMembers = raw ? JSON.parse(raw) : [];
-          
+
           // One-time migration from old `completedReenlistment` flag to new `status` field
           let migrated = false;
           loadedMembers.forEach(m => {
@@ -285,7 +285,7 @@
               migrated = true;
             }
           });
-          
+
           members = loadedMembers;
 
           if (migrated) {
@@ -318,6 +318,48 @@
         return map[key] || g;
       }
 
+      function getEpbOwner(member) {
+        if (!member || !member.rank || !member.inprocessingDate) {
+          return 'EPB: N/A';
+        }
+
+        const scodMap = {
+          'AB': '03-31', 'Amn': '03-31', 'A1C': '03-31', 'SrA': '03-31',
+          'SSgt': '01-31',
+          'TSgt': '11-30',
+          'MSgt': '09-30',
+          'SMSgt': '07-31',
+          'CMSgt': '05-31'
+        };
+
+        const scodMonthDay = scodMap[member.rank];
+        if (!scodMonthDay) return 'EPB: N/A';
+
+        const inprocessingDate = new Date(member.inprocessingDate + 'T00:00:00');
+        if (isNaN(inprocessingDate.getTime())) return 'EPB: N/A';
+
+        const inprocessingYear = inprocessingDate.getFullYear();
+        let scodYear = inprocessingYear;
+
+        const scodDateForInprocessingYear = new Date(`${inprocessingYear}-${scodMonthDay}T00:00:00`);
+
+        if (inprocessingDate > scodDateForInprocessingYear) {
+            scodYear++;
+        }
+
+        const scod = new Date(`${scodYear}-${scodMonthDay}T00:00:00`);
+
+        let accountingDate = new Date(scod);
+        accountingDate.setDate(accountingDate.getDate() - 120);
+        accountingDate.setDate(3);
+
+        if (inprocessingDate <= accountingDate) {
+          return 'EPB: This Unit';
+        } else {
+          return 'EPB: Previous Unit';
+        }
+      }
+
       function itemHTML(m) {
         const displayName = formatDisplayName(m.name);
         return `<div class="member-item">
@@ -331,6 +373,7 @@
                 m.assignmentEligible === false ? 'Needs Retainability' : '—'
               }
               | Status: ${m.status}
+              | ${getEpbOwner(m)}
             </small>
           </div>
           <div class="member-actions">
@@ -342,7 +385,7 @@
       function render() {
         const now = new Date();
         const ninetyDaysFromNow = new Date(now.getTime() + 90 * 24 * 60 * 60 * 1000);
-        
+
         $('#totalMembers').textContent = members.length;
         $('#upcomingActions').textContent = members.filter(m => { const d = new Date(m.dos); return d <= ninetyDaysFromNow && d > now && m.status !== 'completed'; }).length;
         $('#eligibleCount').textContent = members.filter(m => m.status === 'eligible').length;
@@ -377,7 +420,7 @@
           container.innerHTML = '<div class="alert alert-info"><strong>No members currently tracked.</strong><br/>Use the "Add New Member" button to start tracking.</div>';
           return;
         }
-        
+
         // Add quick filter controls if not present
         if (!document.getElementById('statusFilterBar')) {
           const filterBar = document.createElement('div');
@@ -516,7 +559,8 @@
             rank: headerCells.findIndex(h => h.includes('grade') || h === 'rank' || h.includes('pay grade')),
             afsc: headerCells.findIndex(h => h.includes('dafsc') || h.includes('afsc')),
             dos: headerCells.findIndex(h => h === 'dos' || h.includes('ets') || h.includes('separation')),
-            deros: headerCells.findIndex(h => h === 'deros' || h.includes('return from overseas'))
+            deros: headerCells.findIndex(h => h === 'deros' || h.includes('return from overseas')),
+            inprocessingDate: headerCells.findIndex(h => h.includes('inprocessingdate') || h.includes('in processing date'))
           };
           if (colIndex.name === -1 || colIndex.rank === -1 || colIndex.dos === -1) {
             toast(`CSV headers do not look correct. Missing FULL_NAME/NAME, GRADE/RANK, or DOS. Parsed header: [${headerCells.join(', ')}]`, 'danger');
@@ -544,6 +588,7 @@
               afsc: colIndex.afsc !== -1 ? (values[colIndex.afsc] ?? '') : '',
               dos: values[colIndex.dos] ?? '',
               deros: colIndex.deros !== -1 ? (values[colIndex.deros] ?? '') : '',
+              inprocessingDate: colIndex.inprocessingDate !== -1 ? (values[colIndex.inprocessingDate] ?? '') : '',
               status: 'pending'
             };
           }).filter(d => d && d.name && d.rank && d.dos);
@@ -551,12 +596,12 @@
           if (csvImportData.length === 0) { toast('Could not parse any valid member data from the file.', 'danger'); return; }
 
           const previewEl = $('#csvPreview');
-          const displayHeaders = ['Name', 'Rank', 'AFSC', 'DOS', 'DEROS', 'Status'];
+          const displayHeaders = ['Name', 'Rank', 'AFSC', 'DOS', 'DEROS', 'In-processing Date', 'Status'];
           previewEl.innerHTML =
             `<table class="form-control" style="width:100%; text-align: left;">
               <thead><tr>${displayHeaders.map(h=>`<th>${h}</th>`).join('')}</tr></thead>
               <tbody>${csvImportData.map(d=>`<tr>
-                <td>${d.name}</td><td>${normalizeGrade(d.rank)}</td><td>${d.afsc}</td><td>${d.dos}</td><td>${d.deros || ''}</td><td>${d.status}</td>
+                <td>${d.name}</td><td>${normalizeGrade(d.rank)}</td><td>${d.afsc}</td><td>${d.dos}</td><td>${d.deros || ''}</td><td>${d.inprocessingDate || ''}</td><td>${d.status}</td>
               </tr>`).join('')}</tbody>
               </table>`;
           $('#btnConfirmImport').disabled = false;
@@ -570,12 +615,14 @@
         csvImportData.forEach(item => {
           const parsedDos = parseDosDate(item.dos);
           const parsedDeros = item.deros ? parseDosDate(item.deros) : null;
+          const parsedInprocessingDate = item.inprocessingDate ? parseDosDate(item.inprocessingDate) : null;
           if (item.name && item.rank && parsedDos) {
             const member = {
               name: item.name,
               rank: item.rank,
               dos: parsedDos,
               deros: parsedDeros || null,
+              inprocessingDate: parsedInprocessingDate || null,
               afsc: item.afsc || 'N/A',
               status: item.status || 'pending',
               id: Date.now() + Math.random()
@@ -602,7 +649,7 @@
         const resultsEl = $('#eligibilityResults');
         const issues = [];
         const warnings = [];
-        
+
         // Disqualifying factors
         if ($('#uif').checked) issues.push("Has a UIF.");
         if ($('#lostTime').checked) issues.push("Has 5 or more days of lost time.");
@@ -611,10 +658,10 @@
         if ($('#pendingLegal').checked) issues.push("Has pending legal action.");
         const reCode = $('#reCode').value;
         if (reCode.startsWith('2') || reCode.startsWith('4')) issues.push(`RE Code (${reCode}) indicates ineligibility.`);
-        
+
         // Warnings
         if ($('#nonUsCitizen').checked) warnings.push("Is a non-US Citizen (may require additional processing).");
-        
+
         // Reenlistment Window Check
         const memberType = $('#memberType').value;
         const enlistmentLength = parseInt($('#enlistmentLength').value, 10);
@@ -650,7 +697,7 @@
         months -= dosDate.getMonth();
         months += reqDate.getMonth();
         const requiredMonths = months <= 0 ? 0 : months + (reqDate.getDate() > dosDate.getDate() ? 1 : 0);
-        
+
         if(requiredMonths > 48) {
           resultEl.innerHTML = `<div class="alert alert-danger"><h4>Extension Required: ${requiredMonths} months</h4><p><strong>Warning:</strong> This exceeds the 48-month maximum extension limit per enlistment.</p></div>`;
         } else {
@@ -690,6 +737,7 @@
         $('#memberRank').value = member.rank;
         $('#memberDOS').value = member.dos;
         $('#memberDEROS').value = member.deros || '';
+        $('#memberInprocessingDate').value = member.inprocessingDate || '';
         $('#memberAFSC').value = member.afsc;
         setSelectValueOrDefault($('#memberStatus'), member.status, 'pending');
         showModal('modalAddMember');
@@ -700,6 +748,7 @@
           name: $('#memberName').value.trim(),
           rank: $('#memberRank').value,
           dos: $('#memberDOS').value,
+          inprocessingDate: $('#memberInprocessingDate').value,
           afsc: $('#memberAFSC').value.trim(),
           status: $('#memberStatus').value
         };
@@ -725,7 +774,7 @@
           members.push(newMember);
           toast('Member added successfully', 'success');
         }
-        
+
         editingId = null;
         save();
         render();
@@ -808,7 +857,7 @@
 
         $('#memberSearch').addEventListener('input', (e) => {
           const searchTerm = e.target.value.toLowerCase();
-          const filtered = members.filter(m => 
+          const filtered = members.filter(m =>
             (formatDisplayName(m.name) || '').toLowerCase().includes(searchTerm) ||
             (m.rank || '').toLowerCase().includes(searchTerm) ||
             (m.afsc && m.afsc.toLowerCase().includes(searchTerm))


### PR DESCRIPTION
This commit introduces a new feature to calculate and display the ownership of a member's Enlisted Performance Brief (EPB).

- Adds a new "In-processing Date" field to the member data model and the Add/Edit Member UI.
- Updates the CSV import functionality to recognize and handle the new "inprocessingdate" column.
- Implements a `getEpbOwner` function that determines EPB ownership ("This Unit" or "Previous Unit") based on the member's rank and in-processing date, according to the logic defined in AFI36-2406.
- Integrates this logic into the member list display, showing a new tag for EPB ownership next to the member's status.