### PR TITLE
feat: Add EPB ownership status tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -560,7 +560,7 @@
             afsc: headerCells.findIndex(h => h.includes('dafsc') || h.includes('afsc')),
             dos: headerCells.findIndex(h => h === 'dos' || h.includes('ets') || h.includes('separation')),
             deros: headerCells.findIndex(h => h === 'deros' || h.includes('return from overseas')),
-            inprocessingDate: headerCells.findIndex(h => h.includes('inprocessingdate') || h.includes('in processing date'))
+            inprocessingDate: headerCells.findIndex(h => h.includes('inprocessingdate') || h.includes('in processing date') || h.includes('date arrived station'))
           };
           if (colIndex.name === -1 || colIndex.rank === -1 || colIndex.dos === -1) {
             toast(`CSV headers do not look correct. Missing FULL_NAME/NAME, GRADE/RANK, or DOS. Parsed header: [${headerCells.join(', ')}]`, 'danger');


### PR DESCRIPTION
This commit introduces a new feature to calculate and display the ownership of a member's Enlisted Performance Brief (EPB).

- Adds a new "In-processing Date" field to the member data model and the Add/Edit Member UI.
- Updates the CSV import functionality to recognize "inprocessingdate", "in processing date", and "date arrived station" as valid headers for the new data field.
- Implements a `getEpbOwner` function that determines EPB ownership ("This Unit" or "Previous Unit") based on the member's rank and in-processing date, according to the logic defined in AFI36-2406.
- Integrates this logic into the member list display, showing a new tag for EPB ownership next to the member's status.